### PR TITLE
ci: :green_heart: widgetbook pr integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,6 @@ jobs:
                 --actor \
                 $GITHUB_ACTOR \
                 --branch \
-                $GITHUB_HEAD_REF
+                $GITHUB_HEAD_REF \
+                --pr ${{ github.event.number }} \
+                --github-token ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- adds the `--pr` and `--github-token` arguments to the `widgetbook_cli` execution

## Status

**READY**

## Description

Adding `--pr` and `--github-token` arguments to `widgetbook` CLI will enable the CLI to post comments with the link to the Widgetbook Cloud build and reviews. The links make the builds and reviews more accessible. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
