### PR TITLE
refactor: moves macOS check for video media into the TweetMedia widget

### DIFF
--- a/app_widgetbook/lib/core/tweet/tweet_media.dart
+++ b/app_widgetbook/lib/core/tweet/tweet_media.dart
@@ -1,6 +1,5 @@
 import 'package:app_widgetbook/dummy_data/dummy_media.dart';
 import 'package:core/core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart' show Knobs, Option;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
@@ -38,25 +37,17 @@ Widget tweetMediaGalleryUseCase(BuildContext context) {
 
 @WidgetbookUseCase(name: 'GIF', type: TweetMedia)
 Widget tweetMediaGIFUseCase(BuildContext context) {
-  if (defaultTargetPlatform == TargetPlatform.macOS && !kIsWeb) {
-    return const Center(
-      child: Text(
-        'Video player is not supported on MacOS ☹️',
-      ),
-    );
-  } else {
-    return TweetMedia(
-      tweetMedia: DummyMedia.gifMedia,
-      autoPlay: context.knobs.boolean(
-        label: 'Auto Play',
-        description: 'Turning off Auto Play will'
-            ' show a Play button',
-        initialValue: true,
-      ),
-      hasDecoration: context.knobs.boolean(
-        label: 'Has Decoration',
-        initialValue: true,
-      ),
-    );
-  }
+  return TweetMedia(
+    tweetMedia: DummyMedia.gifMedia,
+    autoPlay: context.knobs.boolean(
+      label: 'Auto Play',
+      description: 'Turning off Auto Play will'
+          ' show a Play button',
+      initialValue: true,
+    ),
+    hasDecoration: context.knobs.boolean(
+      label: 'Has Decoration',
+      initialValue: true,
+    ),
+  );
 }

--- a/app_widgetbook/lib/utils.dart
+++ b/app_widgetbook/lib/utils.dart
@@ -1,6 +1,5 @@
 import 'package:app_widgetbook/dummy_data/dummy_media.dart';
 import 'package:core/core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -96,11 +95,10 @@ List<Media> getMediaOptions(
         label: 'Image',
         value: DummyMedia.singlePhotoMedia,
       ),
-      if (defaultTargetPlatform != TargetPlatform.macOS && kIsWeb)
-        const Option(
-          label: 'GIF',
-          value: DummyMedia.gifMedia,
-        ),
+      const Option(
+        label: 'GIF',
+        value: DummyMedia.gifMedia,
+      ),
       const Option(
         label: 'No Media',
         value: [],

--- a/packages/core/lib/src/widgets/tweet/tweet_media.dart
+++ b/packages/core/lib/src/widgets/tweet/tweet_media.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Tweet media widget
@@ -45,12 +46,28 @@ class TweetMedia extends StatelessWidget {
           mediaWidget = TweetImage(imageUrl: tweetMedia[0].url);
           break;
         case MediaType.gif:
+          if (defaultTargetPlatform == TargetPlatform.macOS && !kIsWeb) {
+            mediaWidget = const Center(
+              child: Text(
+                'Video player is not supported on MacOS ☹️',
+              ),
+            );
+            break;
+          }
           mediaWidget = TweetGif(
             gifUrl: tweetMedia[0].url,
             autoPlay: autoPlay,
           );
           break;
         case MediaType.video:
+          if (defaultTargetPlatform == TargetPlatform.macOS && !kIsWeb) {
+            mediaWidget = const Center(
+              child: Text(
+                'Video player is not supported on MacOS ☹️',
+              ),
+            );
+            break;
+          }
           mediaWidget = Container();
           break;
       }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Moved the check:

```
defaultTargetPlatform == TargetPlatform.macOS && !kIsWeb
```

Inside the `TweetMedia` widget instead of writing it for all usages.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
