### PR TITLE
refactor: drawer animation RTL and dynamic width

### DIFF
--- a/app_widgetbook/lib/core/ui_elements/drawer_page_wrapper.dart
+++ b/app_widgetbook/lib/core/ui_elements/drawer_page_wrapper.dart
@@ -1,23 +1,24 @@
 import 'package:app_widgetbook/dummy_data/dummy_users.dart';
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
-import 'package:widgetbook/widgetbook.dart' show Knobs, Option, Device;
+import 'package:widgetbook/widgetbook.dart' show Knobs;
 import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 @WidgetbookUseCase(name: 'Default', type: DrawerPageWrapper)
 Widget drawerPageWrapperDefaultUseCase(BuildContext context) {
-  return DrawerPageWrapper(
-    // Todo: remove these values when `MediaQuery` issue is resolved
-    // now the width and height here are the hardcoded values of an iPhone 12/13
-    width: 390 + DrawerUtils.width,
-    height: 844,
-    user: DummyUsers.widgetbook,
-    appBarTitle: Text(
-      context.knobs.text(
-        label: 'AppBar Title',
-        initialValue: 'Home',
-      ),
+  return MediaQuery(
+    data: MediaQuery.of(context).copyWith(
+      size: const Size(390, 844),
     ),
-    body: Container(),
+    child: DrawerPageWrapper(
+      user: DummyUsers.widgetbook,
+      appBarTitle: Text(
+        context.knobs.text(
+          label: 'AppBar Title',
+          initialValue: 'Home',
+        ),
+      ),
+      body: Container(),
+    ),
   );
 }

--- a/packages/core/lib/src/l10n/app_localizations_extension.dart
+++ b/packages/core/lib/src/l10n/app_localizations_extension.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+
+/// List of RTL (Right-to-Left) languages locale codes
+///
+/// https://lingohub.com/academy/best-practices/rtl-language-list
+List<String> rtlLocales = [
+  'ar',
+  'arc',
+  'dv',
+  'fa',
+  'ha',
+  'he',
+  'khw',
+  'ks',
+  'ku',
+  'ps',
+  'ur',
+  'yi',
+];
+
+/// Localization extension on the [BuildContext]
+extension AppLocalization on BuildContext {
+  /// Retrieves locale code from context
+  ///
+  /// To be able to use `context.localeCode`
+  /// instead of the longer `Localizations.localeOf(context).languageCode`
+  String get localeCode {
+    return Localizations.localeOf(this).languageCode;
+  }
+
+  /// Whether the current localization language is RTL
+  bool get isRTL {
+    return rtlLocales.contains(localeCode);
+  }
+}

--- a/packages/core/lib/src/utils/drawer_utils.dart
+++ b/packages/core/lib/src/utils/drawer_utils.dart
@@ -3,7 +3,12 @@ import 'package:flutter/material.dart';
 /// Utility class for the drawer of the app
 class DrawerUtils {
   /// Width of the drawer
-  static const double width = 300;
+  static const double widthFraction = 0.75;
+
+  /// Dynamic width of drawer based on screen width
+  static double getWidth(BuildContext context) {
+    return MediaQuery.of(context).size.width * widthFraction;
+  }
 
   /// Animation duration of the drawer opening and closing
   static const Duration animationDuration = Duration(milliseconds: 200);

--- a/packages/core/lib/src/widgets/ui/navigation/drawer_page_wrapper.dart
+++ b/packages/core/lib/src/widgets/ui/navigation/drawer_page_wrapper.dart
@@ -1,4 +1,5 @@
 import 'package:core/core.dart';
+import 'package:core/src/l10n/app_localizations_extension.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -10,9 +11,6 @@ class DrawerPageWrapper extends StatefulWidget {
     required this.user,
     required this.body,
     required this.appBarTitle,
-    this.drawerWidth = DrawerUtils.width,
-    this.width,
-    this.height,
   });
 
   /// The logged in user
@@ -24,15 +22,6 @@ class DrawerPageWrapper extends StatefulWidget {
   /// The AppBar title of the page
   final Widget appBarTitle;
 
-  /// Optional width
-  final double? width;
-
-  /// Optional height
-  final double? height;
-
-  /// Width of the drawer
-  final double drawerWidth;
-
   @override
   State<DrawerPageWrapper> createState() => _DrawerPageWrapperState();
 }
@@ -40,7 +29,7 @@ class DrawerPageWrapper extends StatefulWidget {
 class _DrawerPageWrapperState extends State<DrawerPageWrapper>
     with SingleTickerProviderStateMixin {
   late final AnimationController animationController;
-  late final Animation<double> xOffsetAnimation;
+  late final Animation<double> progress;
   int currentIndex = 0;
 
   @override
@@ -50,31 +39,37 @@ class _DrawerPageWrapperState extends State<DrawerPageWrapper>
       duration: DrawerUtils.animationDuration,
     );
 
-    xOffsetAnimation = Tween<double>(
-      begin: -widget.drawerWidth,
+    progress = Tween<double>(
+      begin: -1,
       end: 0,
     ).animate(
       CurvedAnimation(
-          parent: animationController, curve: DrawerUtils.animationCurve),
+        parent: animationController,
+        curve: DrawerUtils.animationCurve,
+      ),
     );
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
+    final drawerWidth = DrawerUtils.getWidth(context);
     return InteractiveViewer(
       constrained: false,
       panEnabled: false,
       scaleEnabled: false,
       child: SizedBox(
-        width: widget.width ??
-            widget.drawerWidth + MediaQuery.of(context).size.width,
-        height: widget.height ?? MediaQuery.of(context).size.height,
+        width: drawerWidth + MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height,
         child: AnimatedBuilder(
           animation: animationController,
           builder: (_, child) {
             return Transform.translate(
-              offset: Offset(xOffsetAnimation.value, 0),
+              offset: Offset(
+                (context.isRTL ? (-1 - progress.value) : progress.value) *
+                    drawerWidth,
+                0,
+              ),
               child: GestureDetector(
                 dragStartBehavior: DragStartBehavior.down,
                 behavior: HitTestBehavior.opaque,
@@ -84,7 +79,7 @@ class _DrawerPageWrapperState extends State<DrawerPageWrapper>
                 child: Row(
                   children: [
                     SizedBox(
-                      width: widget.drawerWidth,
+                      width: drawerWidth,
                       child: AppDrawer(user: widget.user),
                     ),
                     Expanded(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Refactoring done:
* Instead of `width` and `height` passed down to `DrawerPageWrapper`, a workaround was implemented by wrapping the use case with a `MediaQuery` with the size values of an iPhone 12/13 frame. This can be removed later when the `MediaQuery` issue is resolved.
* Instead of hard coded `320` drawer width, the drawer now can have a width dependent on the width of this screen (the previously mentioned workaround made this possible).
* Added RTL support to the drawer animation (slides in from the right).
* Added `AppLocalization` extension on `BuildContext` for a shortcut to `localeCode` and `isRTL` value.
* Added list of all RTL language locales based on [this source](https://lingohub.com/academy/best-practices/rtl-language-list).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
