### PR TITLE
fix: AppDrawer footer icon colors

### DIFF
--- a/packages/core/lib/src/widgets/ui/navigation/app_drawer.dart
+++ b/packages/core/lib/src/widgets/ui/navigation/app_drawer.dart
@@ -124,11 +124,21 @@ class AppDrawer extends StatelessWidget {
                   children: [
                     AppIconButton(
                       onPressed: () {},
-                      icon: const Icon(TwitterIcons.bulb),
+                      icon: Icon(
+                        TwitterIcons.bulb,
+                        color: Theme.of(context).isDark
+                            ? AppColors.white
+                            : AppColors.secondary,
+                      ),
                     ),
                     AppIconButton(
                       onPressed: () {},
-                      icon: const Icon(TwitterIcons.qr),
+                      icon: Icon(
+                        TwitterIcons.qr,
+                        color: Theme.of(context).isDark
+                            ? AppColors.white
+                            : AppColors.secondary,
+                      ),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Status

**READY**

## Description

AppDrawer footer icon colors were light black instead of black.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
