### PR TITLE
ci: :arrow_up: bump CLI version

### DIFF
--- a/.github/workflows/upload-review.yml
+++ b/.github/workflows/upload-review.yml
@@ -29,7 +29,7 @@ jobs:
         run: flutter build web -t lib/app.widgetbook.dart
 
       - name: Install Widgetbook CLI
-        run: dart pub global activate widgetbook_cli 3.0.0-beta.17
+        run: dart pub global activate widgetbook_cli 3.0.0-beta.18
 
       - name: Upload Widgetbook
         run: |


### PR DESCRIPTION

## Status

**READY**

## Description

Bumps `widgetbook_cli` version from `3.0.0-beta.17` to `3.0.0-beta.18` which will enable Review links

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
